### PR TITLE
Support for VLC 3.0

### DIFF
--- a/youtube.lua
+++ b/youtube.lua
@@ -107,8 +107,8 @@ function js_descramble( sig, js_url )
     end
 
     -- Look for the descrambler function's name
-    -- c&&a.set("signature",br(c));
-    local descrambler = js_extract( js, "%.set%(\"signature\",([^)]-)%(" )
+    -- k.s&&f.set(k.sp||"signature",DK(k.s));
+    local descrambler = js_extract( js, "%.set%([^,]-\"signature\",([^)]-)%(" )
     if not descrambler then
         vlc.msg.dbg( "Couldn't extract youtube video URL signature descrambling function name" )
         return sig


### PR DESCRIPTION
Changed the local descrambler from what VLC 2.6.6 used to what VLC 3.0 uses. Did not update the plugin to support YouTube Gaming